### PR TITLE
delete init method and call initialize method in consturctor

### DIFF
--- a/asset_loader/audio.js
+++ b/asset_loader/audio.js
@@ -1,6 +1,20 @@
 'use strict';
 
 var AudioLoader = function() {
+	this.audio_context = null;
+	if (window && window.AudioContext) {
+		this.audio_context = new window.AudioContext();
+
+		// for legacy browser
+		this.audio_context.createGain = this.audio_context.createGain || this.audio_context.createGainNode;
+	}
+
+	this.initialize();
+};
+AudioLoader.prototype.initialize = function() {
+	// cancel already playing bgms if initialize method is called by re-initialize
+	this.stopAllBGM();
+
 	this.sounds = {};
 	this.bgms = {};
 
@@ -11,32 +25,7 @@ var AudioLoader = function() {
 	// which determine what sound is played.
 	this._reserved_play_sound_name_map = {};
 
-	this.audio_context = null;
-	if (window && window.AudioContext) {
-		this.audio_context = new window.AudioContext();
-
-		// for legacy browser
-		this.audio_context.createGain = this.audio_context.createGain || this.audio_context.createGainNode;
-	}
-
 	// key: bgm name, value: playing AudioBufferSourceNode instance
-	this._audio_source_map = {};
-};
-AudioLoader.prototype.init = function() {
-	// cancel already playing bgms if init method is called by re-init
-	this.stopAllBGM();
-
-	// TODO: cancel already playing sound?
-	// TODO: cancel already loading bgms and sounds
-
-	this.sounds = {};
-	this.bgms = {};
-
-	this.loading_audio_num = 0;
-	this.loaded_audio_num = 0;
-
-	this._reserved_play_sound_name_map = {};
-
 	this._audio_source_map = {};
 };
 

--- a/asset_loader/font.js
+++ b/asset_loader/font.js
@@ -7,12 +7,10 @@
 // - add comment
 
 var FontLoader = function() {
-	this._isLoadedDone = false;
-	this._loadedFonts  = null;
-	this._fontStatues  = {};
 	this._hiddenCanvas = null;
+	this.initialize();
 };
-FontLoader.prototype.init = function() {
+FontLoader.prototype.initialize = function() {
 	this._isLoadedDone = false;
 	this._loadedFonts  = null;
 	this._fontStatues  = {};
@@ -43,7 +41,7 @@ FontLoader.prototype.progress = function() {
 FontLoader.prototype.setupEvents = function() {
 	var self = this;
 	if(self.canUseCssFontLoading()) {
-		// TODO: after all font loading, calling init method and adding same font loading can't fire ready event
+		// TODO: after all font loading, calling initialize method and adding same font loading can't fire ready event
 		window.document.fonts.ready.then(function(fonts){
 			self._isLoadedDone = true;
 			self._loadedFonts = fonts;

--- a/asset_loader/image.js
+++ b/asset_loader/image.js
@@ -1,17 +1,13 @@
 'use strict';
 
 var ImageLoader = function() {
-	this.images = {};
-
-	this.loading_image_num = 0;
-	this.loaded_image_num = 0;
+	this.initialize();
 };
-ImageLoader.prototype.init = function() {
+ImageLoader.prototype.initialize = function() {
 	// cancel already loading images
 	for(var name in this.images){
 		this.images[name].image.src = "";
 	}
-
 	this.images = {};
 
 	this.loading_image_num = 0;

--- a/core.js
+++ b/core.js
@@ -61,9 +61,20 @@ var Core = function(canvas, options) {
 	this.save_manager = new SaveManager();
 	this.input_manager = new InputManager();
 
+	this.image_loader = new ImageLoader();
+	this.audio_loader = new AudioLoader();
+	this.font_loader = new FontLoader();
+
 	this.width = Number(canvas.getAttribute('width'));
 	this.height = Number(canvas.getAttribute('height'));
 
+	// add default save
+	this.save_manager.addClass("scenario", StorageScenario);
+
+	this.initialize();
+};
+
+Core.prototype.initialize = function () {
 	this.current_scene = null;
 	this._reserved_next_scene = null; // next scene which changes next frame run
 	this.scenes = {};
@@ -75,39 +86,23 @@ var Core = function(canvas, options) {
 
 	this.request_id = null;
 
-	this.image_loader = new ImageLoader();
-	this.audio_loader = new AudioLoader();
-	this.font_loader = new FontLoader();
-
 	// add default scene
 	this.addScene("loading", new SceneLoading(this));
 
-	// add default save
-	this.save_manager.addClass("scenario", StorageScenario);
-};
-Core.prototype.init = function () {
-	this.current_scene = null;
-	this._reserved_next_scene = null; // next scene which changes next frame run
-
-	this.frame_count = 0;
-
-	this.request_id = null;
-
-	this.debug_manager.init();
-	this.time_manager.init();
+	this.debug_manager.initialize();
+	this.time_manager.initialize();
 	// TODO:
-	//this.save_manager.init();
-	this.input_manager.init();
+	//this.save_manager.initialize();
+	this.input_manager.initialize();
 
-	this.image_loader.init();
-	this.audio_loader.init();
-	this.font_loader.init();
+	this.image_loader.initialize();
+	this.audio_loader.initialize();
+	this.font_loader.initialize();
 
 	this.save_manager.initialLoad();
 };
-
 Core.prototype.reload = function () {
-	this.init();
+	this.initialize();
 };
 
 Core.prototype.isRunning = function () {
@@ -202,7 +197,9 @@ Core.prototype.changeNextSceneIfReserved = function() {
 			// change next scene
 			this.current_scene = this._reserved_next_scene.shift();
 			var current_scene = this.currentScene();
-			current_scene.init.apply(current_scene, this._reserved_next_scene);
+
+			// call changed method
+			current_scene.changed.apply(current_scene, this._reserved_next_scene);
 
 			this._reserved_next_scene = null;
 		}
@@ -350,7 +347,7 @@ Core.prototype._setupError = function() {
 		// or
 
 		// restart game at first point
-		//self.init();
+		//self.initialize();
 		//self.startRun();
 	};
 };

--- a/manager/debug.js
+++ b/manager/debug.js
@@ -10,23 +10,22 @@ var DebugManager = function (core) {
 
 	this.is_debug_mode = false; // default: false
 
-
 	this._is_showing_collision_area = false; // default: false
 
 	this._is_showing_fps = false; // default: false
 
 	this._variables = {};
 
+	this.initialize();
+};
+DebugManager.prototype.initialize = function () {
 	// Time when FPS was calculated last time(millisecond)
 	this._before_time = 0;
 
 	// calculated current fps
 	this._fps = 0;
 };
-DebugManager.prototype.init = function () {
-	this._before_time = 0;
-	this._fps = 0;
-};
+
 DebugManager.prototype.setOn = function (dom) {
 	this.is_debug_mode = true;
 	this.dom = dom;

--- a/manager/input.js
+++ b/manager/input.js
@@ -13,9 +13,11 @@ var DEFAULT_BUTTON_ID_TO_BIT_CODE = {
 };
 
 var InputManager = function () {
+	this.initialize();
+};
+InputManager.prototype.initialize = function () {
 	this.current_keyflag = 0x0;
 	this.before_keyflag = 0x0;
-	this._key_bit_code_to_down_time = {};
 
 	// gamepad button_id to bit code of key input
 	this._button_id_to_key_bit_code = Util.shallowCopyHash(DEFAULT_BUTTON_ID_TO_BIT_CODE);
@@ -31,28 +33,10 @@ var InputManager = function () {
 	this.mouse_scroll = 0;
 
 	this.is_connect_gamepad = false;
+
+	this._initPressedKeyTime();
 };
 
-InputManager.prototype.init = function () {
-	this.current_keyflag = 0x0;
-	this.before_keyflag = 0x0;
-	this.initPressedKeyTime();
-
-	// gamepad button_id to bit code of key input
-	this._button_id_to_key_bit_code = Util.shallowCopyHash(DEFAULT_BUTTON_ID_TO_BIT_CODE);
-
-	this.is_left_clicked  = false;
-	this.is_right_clicked = false;
-	this.before_is_left_clicked  = false;
-	this.before_is_right_clicked = false;
-	this.mouse_change_x = 0;
-	this.mouse_change_y = 0;
-	this.mouse_x = 0;
-	this.mouse_y = 0;
-	this.mouse_scroll = 0;
-
-	this.is_connect_gamepad = false;
-};
 InputManager.prototype.enableGamePad = function () {
 	this.is_connect_gamepad = true;
 };
@@ -155,7 +139,6 @@ InputManager.prototype.mousePositionPoint = function (scene) {
 	var y = this.mousePositionY();
 
 	var point = new ObjectPoint(scene);
-	point.init();
 	point.setPosition(x, y);
 
 
@@ -255,7 +238,7 @@ InputManager.prototype.handleGamePad = function() {
 			this.current_keyflag &= ~CONSTANT.BUTTON_RIGHT;
 	}
 };
-InputManager.prototype.initPressedKeyTime = function() {
+InputManager.prototype._initPressedKeyTime = function() {
 	this._key_bit_code_to_down_time = {};
 
 	for (var button_id in CONSTANT) {

--- a/manager/scenario.js
+++ b/manager/scenario.js
@@ -24,45 +24,13 @@ var ScenarioManager = function (core, option) {
 
 	this._timeoutID = null;
 
-	// serif scenario
-	this._script = null;
-
-	// where serif has progressed
-	this._progress = null;
-
-	// chara
-	this._current_talking_pos  = null; // which chara is talking
-	this._pos_to_chara_id_map = {};
-	this._pos_to_exp_id_map = {};
-
-	// background
-	this._is_background_changed = false;
-	this._current_bg_image_name  = null;
-
-	// junction
-	this._current_junction_list = [];
-
-	// option
-	this._current_option = {};
-
-	// letter data to print
-	this._current_message_letter_list = [];
-	this._current_message_sentenses_num = null;
-	this._current_message_max_length_letters = null;
-
-	// current printed sentences
-	this._letter_idx = 0;
-	this._sentences_line_num = 0;
-	this._current_printed_sentences = [];
+	this.initialize();
 };
+
 Util.inherit(ScenarioManager, BaseClass);
 
-ScenarioManager.prototype.init = function (script) {
-	if(!script) throw new Error("set script arguments to use scenario_manager class");
-
+ScenarioManager.prototype.initialize = function () {
 	if (this._timeoutID) this._stopPrintLetter();
-
-	this._script = script.slice(); // shallow copy
 
 	this._progress = -1;
 
@@ -91,6 +59,10 @@ ScenarioManager.prototype.init = function (script) {
 	this._sentences_line_num = 0;
 	this._current_printed_sentences = [];
 };
+ScenarioManager.prototype.setScript = function (script) {
+	this._script = script.slice(); // shallow copy
+};
+
 ScenarioManager.prototype.on = function (event, callback) {
 	this._event_to_callback[event] = callback;
 

--- a/manager/time.js
+++ b/manager/time.js
@@ -5,9 +5,9 @@ var ID = 0;
 var TimeManager = function (core) {
 	this.core = core;
 
-	this.events = {};
+	this.initialize();
 };
-TimeManager.prototype.init = function () {
+TimeManager.prototype.initialize = function () {
 	this.events = {};
 };
 

--- a/object/_base_and_point_classes.js
+++ b/object/_base_and_point_classes.js
@@ -17,12 +17,21 @@ var ObjectBase = function(scene) {
 	this.parent = null; // parent object if this is sub object
 	this.id = ++id;
 
-	this.frame_count = 0;
-
 	this._x = 0; // local center x
 	this._y = 0; // local center y
 
-	// manage flags that disappears in frame elapsed
+	// sub object
+	this.objects = [];
+
+	this.initialize();
+};
+
+Util.defineProperty(ObjectBase, "x");
+Util.defineProperty(ObjectBase, "y");
+
+ObjectBase.prototype.initialize = function(){
+	this.frame_count = 0;
+
 	this._auto_disable_times_map = {};
 
 	this._velocity = null;
@@ -31,30 +40,8 @@ var ObjectBase = function(scene) {
 	this._previous_x = null;
 	this._previous_y = null;
 
-	// sub object
-	this.objects = [];
-
-};
-
-Util.defineProperty(ObjectBase, "x");
-Util.defineProperty(ObjectBase, "y");
-
-ObjectBase.prototype.init = function(){
-	this.frame_count = 0;
-
-	// NOTE: abolished
-	//this._x = 0;
-	//this._y = 0;
-
-	this._auto_disable_times_map = {};
-
-	this.resetVelocity();
-
-	this._previous_x = null;
-	this._previous_y = null;
-
 	for(var i = 0, len = this.objects.length; i < len; i++) {
-		this.objects[i].init();
+		this.objects[i].initialize();
 	}
 };
 
@@ -259,7 +246,6 @@ ObjectBase.prototype.checkCollisionWithObjects = function(objs) {
 // check Collision Detect with (x, y) and execute onCollision method if detect
 ObjectBase.prototype.checkCollisionWithPosition = function(x, y) {
 	var point = new ObjectPoint(this.scene);
-	point.init();
 	point.setPosition(x, y);
 
 	return this.checkCollisionWithObject(point);
@@ -336,7 +322,7 @@ ObjectBase.prototype.checkCollisionByObject = function(obj) {
 
 // set flags that disappears in frame elapsed
 // TODO: enable to set flag which becomes false -> true
-// TODO: reset flag if the object calls init method
+// TODO: reset flag if the object calls initialize method
 ObjectBase.prototype.setAutoDisableFlag = function(flag_name, count) {
 	var self = this;
 

--- a/object/pool_manager.js
+++ b/object/pool_manager.js
@@ -9,12 +9,11 @@ var PoolManager = function(scene, Class) {
 	base_object.apply(this, arguments);
 
 	this.Class = Class;
-	this.objects = {};
 };
 util.inherit(PoolManager, base_object);
 
-PoolManager.prototype.init = function() {
-	base_object.prototype.init.apply(this, arguments);
+PoolManager.prototype.initialize = function() {
+	base_object.prototype.initialize.apply(this, arguments);
 
 	this.objects = {};
 };

--- a/object/pool_manager3d.js
+++ b/object/pool_manager3d.js
@@ -10,10 +10,7 @@ var glmat = require('gl-matrix');
 var CONSTANT_3D = require('../constant/webgl').SPRITE3D;
 
 var PoolManager3D = function(scene, Class) {
-	base_object.apply(this, arguments);
-
 	this.Class = Class;
-	this.objects = {};
 
 	this.vertices = [];
 	this.coordinates = [];
@@ -28,11 +25,13 @@ var PoolManager3D = function(scene, Class) {
 
 	this.mvMatrix = glmat.mat4.create();
 	this.pMatrix = glmat.mat4.create();
+
+	base_object.apply(this, arguments);
 };
 util.inherit(PoolManager3D, base_object);
 
-PoolManager3D.prototype.init = function() {
-	base_object.prototype.init.apply(this, arguments);
+PoolManager3D.prototype.initialize = function() {
+	base_object.prototype.initialize.apply(this, arguments);
 
 	this.objects = {};
 

--- a/object/sprite.js
+++ b/object/sprite.js
@@ -4,13 +4,11 @@ var util = require('../util');
 
 var Sprite = function(scene) {
 	base_object.apply(this, arguments);
-
-	this.current_sprite_index = 0;
 };
 util.inherit(Sprite, base_object);
 
-Sprite.prototype.init = function(){
-	base_object.prototype.init.apply(this, arguments);
+Sprite.prototype.initialize = function(){
+	base_object.prototype.initialize.apply(this, arguments);
 
 	this.current_sprite_index = 0;
 };

--- a/object/sprite3d.js
+++ b/object/sprite3d.js
@@ -5,10 +5,6 @@ var CONSTANT_3D = require('../constant/webgl').SPRITE3D;
 var glmat = require('gl-matrix');
 
 var Sprite3d = function(scene) {
-	base_object.apply(this, arguments);
-
-	this.current_sprite_index = 0;
-
 	this._z = 0;
 
 	this.vertices = [];
@@ -31,11 +27,13 @@ var Sprite3d = function(scene) {
 
 	this.mvMatrix = glmat.mat4.create();
 	this.pMatrix = glmat.mat4.create();
+
+	base_object.apply(this, arguments);
 };
 util.inherit(Sprite3d, base_object);
 
-Sprite3d.prototype.init = function(){
-	base_object.prototype.init.apply(this, arguments);
+Sprite3d.prototype.initialize = function(){
+	base_object.prototype.initialize.apply(this, arguments);
 
 	this.current_sprite_index = 0;
 

--- a/object/ui/base.js
+++ b/object/ui/base.js
@@ -4,8 +4,6 @@ var BaseObject = require('../base');
 var Util = require('../../util');
 
 var ObjectUIBase = function(scene, option) {
-	BaseObject.apply(this, arguments);
-
 	option = option || {};
 
 	this._default_property = {
@@ -19,18 +17,15 @@ var ObjectUIBase = function(scene, option) {
 		beforedraw: function () {},
 	};
 
-	// children
-	this.objects = this._default_property.children;
-
-	this._show_call_count = 0;
+	BaseObject.apply(this, arguments);
 };
 Util.inherit(ObjectUIBase, BaseObject);
 
-ObjectUIBase.prototype.init = function() {
+ObjectUIBase.prototype.initialize = function() {
 	// reset children
 	this.objects = this._default_property.children;
 
-	BaseObject.prototype.init.apply(this, arguments);
+	BaseObject.prototype.initialize.apply(this, arguments);
 
 	this._show_call_count = 0;
 

--- a/object/ui/group.js
+++ b/object/ui/group.js
@@ -3,8 +3,6 @@
 var BaseObjectUI = require('./base');
 var Util = require('../../util');
 var ObjectUIGroup = function(scene, option) {
-	BaseObjectUI.apply(this, arguments);
-
 	option = option || {};
 
 	this._default_property = Util.assign(this._default_property, {
@@ -12,6 +10,8 @@ var ObjectUIGroup = function(scene, option) {
 		height:          option.height          || 0,
 		backgroundColor: option.backgroundColor || null,
 	});
+
+	BaseObjectUI.apply(this, arguments);
 };
 Util.inherit(ObjectUIGroup, BaseObjectUI);
 
@@ -19,8 +19,8 @@ Util.defineProperty(ObjectUIGroup, "width");
 Util.defineProperty(ObjectUIGroup, "height");
 Util.defineProperty(ObjectUIGroup, "backgroundColor");
 
-ObjectUIGroup.prototype.init = function() {
-	BaseObjectUI.prototype.init.apply(this, arguments);
+ObjectUIGroup.prototype.initialize = function() {
+	BaseObjectUI.prototype.initialize.apply(this, arguments);
 
 	this.width(this._default_property.width);
 	this.height(this._default_property.height);

--- a/object/ui/image.js
+++ b/object/ui/image.js
@@ -3,8 +3,6 @@
 var BaseObjectUI = require('./base');
 var Util = require('../../util');
 var ObjectUIImage = function(scene, option) {
-	BaseObjectUI.apply(this, arguments);
-
 	option = option || {};
 
 	this._default_property = Util.assign(this._default_property, {
@@ -13,6 +11,8 @@ var ObjectUIImage = function(scene, option) {
 		width:      option.width      || null,
 		height:     option.height     || null,
 	});
+
+	BaseObjectUI.apply(this, arguments);
 };
 Util.inherit(ObjectUIImage, BaseObjectUI);
 
@@ -21,8 +21,8 @@ Util.defineProperty(ObjectUIImage, "scale");
 Util.defineProperty(ObjectUIImage, "width");
 Util.defineProperty(ObjectUIImage, "height");
 
-ObjectUIImage.prototype.init = function() {
-	BaseObjectUI.prototype.init.apply(this, arguments);
+ObjectUIImage.prototype.initialize = function() {
+	BaseObjectUI.prototype.initialize.apply(this, arguments);
 
 	this.image_name(this._default_property.image_name);
 	this.scale(this._default_property.scale);

--- a/object/ui/spinner.js
+++ b/object/ui/spinner.js
@@ -6,22 +6,22 @@ var BaseObjectUI = require('./base');
 var Util = require('../../util');
 
 var ObjectUISpinner = function(scene, option) {
-	BaseObjectUI.apply(this, arguments);
-
 	option = option || {};
 
 	this._default_property = Util.assign(this._default_property, {
 		size:  option.size  || "",
 		color: option.color || "black",
 	});
+
+	BaseObjectUI.apply(this, arguments);
 };
 Util.inherit(ObjectUISpinner, BaseObjectUI);
 
 Util.defineProperty(ObjectUISpinner, "size");
 Util.defineProperty(ObjectUISpinner, "color");
 
-ObjectUISpinner.prototype.init = function() {
-	BaseObjectUI.prototype.init.apply(this, arguments);
+ObjectUISpinner.prototype.initialize = function() {
+	BaseObjectUI.prototype.initialize.apply(this, arguments);
 
 	this.size(this._default_property.size);
 	this.color(this._default_property.color);

--- a/object/ui/text.js
+++ b/object/ui/text.js
@@ -3,8 +3,6 @@
 var BaseObjectUI = require('./base');
 var Util = require('../../util');
 var ObjectUIText = function(scene, option) {
-	BaseObjectUI.apply(this, arguments);
-
 	option = option || {};
 
 	this._default_property = Util.assign(this._default_property, {
@@ -13,6 +11,8 @@ var ObjectUIText = function(scene, option) {
 		textSize:  option.textSize  || "24px",
 		textAlign: option.textAlign || "left",
 	});
+
+	BaseObjectUI.apply(this, arguments);
 };
 Util.inherit(ObjectUIText, BaseObjectUI);
 
@@ -21,8 +21,8 @@ Util.defineProperty(ObjectUIText, "textColor");
 Util.defineProperty(ObjectUIText, "textSize");
 Util.defineProperty(ObjectUIText, "textAlign");
 
-ObjectUIText.prototype.init = function() {
-	BaseObjectUI.prototype.init.apply(this, arguments);
+ObjectUIText.prototype.initialize = function() {
+	BaseObjectUI.prototype.initialize.apply(this, arguments);
 
 	this.text(this._default_property.text);
 	this.textColor(this._default_property.textColor);

--- a/scene/base.js
+++ b/scene/base.js
@@ -9,42 +9,19 @@ var SceneBase = function(core) {
 	this.width = this.core.width; // default
 	this.height = this.core.height; // default
 
-	this._x = 0;
-	this._y = 0;
-
-	this.frame_count = 0;
 
 	this.objects = [];
-
-	// sub scenes
-	this.current_scene = null;
-	this._reserved_next_scene = null; // next scene which changes next frame run
-	this.scenes = {};
-
-	// property for fade in
-	this._fade_in_duration = null;
-	this._fade_in_color = null;
-	this._fade_in_start_frame_count = null;
-
-	// property for fade out
-	this._fade_out_duration = null;
-	this._fade_out_color = null;
-	this._fade_out_start_frame_count = null;
-
-	// property for wait to start bgm
-	this._wait_to_start_bgm_name = null;
-	this._wait_to_start_bgm_duration = null;
-	this._wait_to_start_bgm_start_frame_count = null;
-
-	// property for background
-	this._background_color = null;
 
 	// UI view
 	this.ui = new UI(this);
 	this.addObject(this.ui); // TODO: draw after all objects drawed
+
+	this.scenes = {};
+
+	this.initialize();
 };
 
-SceneBase.prototype.init = function(){
+SceneBase.prototype.initialize = function() {
 	// sub scenes
 	this.current_scene = null;
 	this._reserved_next_scene = null; // next scene which changes next frame run
@@ -70,8 +47,12 @@ SceneBase.prototype.init = function(){
 	this._wait_to_start_bgm_start_frame_count = null;
 
 	for(var i = 0, len = this.objects.length; i < len; i++) {
-		this.objects[i].init();
+		this.objects[i].initialize();
 	}
+};
+// this method is called if you call core's changeScene method
+SceneBase.prototype.onChanged = function(argument_list){
+	this.initialize();
 };
 
 SceneBase.prototype.beforeDraw = function(){

--- a/scene/loading.js
+++ b/scene/loading.js
@@ -7,14 +7,16 @@ var util = require('../util');
 
 var SceneLoading = function(core) {
 	base_scene.apply(this, arguments);
-
-	// go if the all assets loading is done.
-	this.next_scene_name = null;
 };
 util.inherit(SceneLoading, base_scene);
 
-SceneLoading.prototype.init = function(assets, next_scene_name) {
-	base_scene.prototype.init.apply(this, arguments);
+SceneLoading.prototype.initialize = function() {
+	// go if the all assets loading is done.
+	this.next_scene_name = null;
+};
+
+SceneLoading.prototype.onChanged = function(assets, next_scene_name) {
+	base_scene.prototype.onChanged.apply(this, arguments);
 
 	// assets
 	var images = assets.images || [];

--- a/scene/movie.js
+++ b/scene/movie.js
@@ -7,11 +7,11 @@ var util = require('../util');
 
 var SceneMovie = function(core) {
 	base_scene.apply(this, arguments);
+};
+util.inherit(SceneMovie, base_scene);
 
-	this.video = null;
-
-	// go if the movie is done.
-	this.next_scene_name = null;
+SceneMovie.prototype.initialize = function() {
+	base_scene.prototype.initialize.apply(this, arguments);
 
 	this.is_playing = false;
 
@@ -20,27 +20,24 @@ var SceneMovie = function(core) {
 	this._top    = null;
 	this._left   = null;
 
+	// go if the movie is done.
+	this.next_scene_name = null;
+
+	this.video = null;
+
 	this.is_mute = false;
 };
-util.inherit(SceneMovie, base_scene);
 
-SceneMovie.prototype.init = function(movie_path, next_scene_name) {
-	base_scene.prototype.init.apply(this, arguments);
+SceneMovie.prototype.onChanged = function(movie_path, next_scene_name) {
+	base_scene.prototype.onChanged.apply(this, arguments);
 
 	var self = this;
-
-	self.is_playing = false;
-
-	self._height = null;
-	self._width  = null;
-	self._top    = null;
-	self._left   = null;
 
 	// go if the movie is done.
 	self.next_scene_name = next_scene_name;
 
 	// stop bgm if it is played.
-	this.core.audio_loader.stopBGM();
+	self.core.audio_loader.stopBGM();
 
 	var video = document.createElement("video");
 	video.src = movie_path;
@@ -54,15 +51,16 @@ SceneMovie.prototype.init = function(movie_path, next_scene_name) {
 		self.is_playing = true;
 	};
 
-	if (this.is_mute) {
+	if (self.is_mute) {
 		video.muted = true;
 	}
 
 	video.load();
 
-
 	self.video = video;
 };
+
+
 
 SceneMovie.prototype.beforeDraw = function(){
 	base_scene.prototype.beforeDraw.apply(this, arguments);

--- a/test/manager/scenario.js
+++ b/test/manager/scenario.js
@@ -15,7 +15,7 @@ describe('ScenarioManager', function() {
 		canvasMockify(canvas);
 
 		core = new Core(canvas);
-		core.init();
+		core.initialize();
 		scenario = new ScenarioManager(core);
 	});
 	after(function () {
@@ -23,10 +23,10 @@ describe('ScenarioManager', function() {
 		scenario._stopPrintLetter();
 	});
 
-    describe('#init()', function() {
+    describe('#setScript()', function() {
 		var script = [];
         it('does not occur error', function(done) {
-			scenario.init(script);
+			scenario.setScript(script);
 			done();
 		});
 	});
@@ -38,7 +38,8 @@ describe('ScenarioManager', function() {
 		];
 
 		beforeEach(function() {
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 		});
 
         it('should start at first serif script', function() {
@@ -60,7 +61,8 @@ describe('ScenarioManager', function() {
 		];
 
 		before(function() {
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 		});
 
         it('check whether is start and end correctly', function() {
@@ -87,7 +89,8 @@ describe('ScenarioManager', function() {
 		];
 
 		beforeEach(function() {
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 			scenario.removeEvent("printend");
 		});
 
@@ -139,7 +142,8 @@ describe('ScenarioManager', function() {
 		];
 
 		beforeEach(function() {
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 			scenario.removeEvent("printend");
 		});
 
@@ -177,7 +181,8 @@ describe('ScenarioManager', function() {
 		];
 
 		before(function() {
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 		});
 
         it('returns background flag correctly', function() {
@@ -209,7 +214,8 @@ describe('ScenarioManager', function() {
 		];
 
 		before(function() {
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 		});
 
         it('change serif correctly', function() {
@@ -276,7 +282,7 @@ describe('ScenarioManager', function() {
 			canvasMockify(canvas);
 
 			core = new Core(canvas);
-			core.init();
+			core.initialize();
 			scenario = new ScenarioManager(core, {
 				criteria: {
 					criteria1: function (core, num) {
@@ -287,7 +293,8 @@ describe('ScenarioManager', function() {
 					},
 				},
 			});
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 		});
 		after(function () {
 			// TODO: fix not call private method
@@ -316,7 +323,8 @@ describe('ScenarioManager', function() {
 		];
 
 		before(function() {
-			scenario.init(script);
+			scenario.setScript(script);
+			scenario.initialize();
 		});
 
         it('saves correct flag', function() {


### PR DESCRIPTION
# Overview
Since it was inconvenient that the implementer must call the `init` method each time an object was constructed, the class called the `init` method in the constructor.
Additionally, rename `init` method to the `initialize` so that the error will occur if the init method is called by no adjusting version-up hakureijs

# Considering
When inheriting, Child classes will be initialized after the initialize method is called.

1. children's constructor is called
2. parent's constructor is called
3. parent's initialization
4. initialize method is called(this initialize method is children's!)
5. parent's initialize logic executed
6. children's initialize logic executed
7. children's initialization